### PR TITLE
Set Vite base path for GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: "/bidimidia-lp/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- configure Vite to build assets relative to the /bidimidia-lp/ subpath for GitHub Pages deployments

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e131baaadc83269b34dcc11982a504